### PR TITLE
Fixed module hanging when HSL service does not return 200 status code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore downloaded node modules
+node_modules

--- a/node_helper.js
+++ b/node_helper.js
@@ -14,6 +14,7 @@ var moment = require('moment');
 
 module.exports = NodeHelper.create({
 	updateTimer: "",
+	retryInterval: 30 * 1000, // The time to wait before retrying after a failed connection to HSL
 	start: function() {
 		this.timesUpdated = 1;
         this.started = false;
@@ -174,8 +175,12 @@ module.exports = NodeHelper.create({
 						stopTimes: stopTimesObj
 					});
 	            }
-	            if (error) {
-	               if(debug){console.log("DEBUG: Error: " + error)} // Show the ERROR
+				else {
+					if(debug){console.log("DEBUG: Error: " + error)} // Show the ERROR
+					clearTimeout(this.updateTimer);
+                    this.updateTimer = setTimeout(function() {
+                        self.updateTransportData(payload);
+                    }, self.retryInterval);
 	            }
 	            //if(debug){console.log("DEBUG: Response: " + body)}; // DEBUG RESPONSE
 	        });


### PR DESCRIPTION
The `node_helper.js` hangs in case HSL API responds with some other HTTP status code than 200. For example, 504 is quite common.

The patch adds a simple timer in case of error or non-OK status code to `updateTransportData()` and calls the same function again with the same parameters after the retry interval.

I've also added a simple `.gitignore` to hide `node_modules` directory from git.